### PR TITLE
fix: switch from BrowserRouter to HashRouter for GitHub Pages

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -2,7 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 
 import {
-  BrowserRouter as Router,
+  HashRouter,
   Switch,
   Route
 } from "react-router-dom";
@@ -13,7 +13,7 @@ import Round from '../Round/Round';
 
 function App() {
   return (
-    <Router>
+    <HashRouter>
       <div className="App">
         <NavBar />
 
@@ -24,8 +24,7 @@ function App() {
           </Switch>
         </div>
       </div>
-
-    </Router>
+    </HashRouter>
   );
 }
 


### PR DESCRIPTION
GitHub Pages doesn’t support routers that use the HTML5 pushState history API under the hood (for example, React Router using browserHistory). Routing using hashes is one solution.