### PR TITLE
Responsive roundicon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "music-club-react",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "music-club-react",
-      "version": "0.11.0",
+      "version": "1.0.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-club-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "homepage": "http://tabrasel.github.io/music-club-client",
   "dependencies": {

--- a/src/CurrentRoundJumbotron/CurrentRoundJumbotron.js
+++ b/src/CurrentRoundJumbotron/CurrentRoundJumbotron.js
@@ -62,7 +62,7 @@ function CurrentRoundJumbotron() {
   if (round === null) return null;
 
   return (
-    <div className={`${styles.CurrentRoundJumbotron} jumbotron d-flex justify-content-between mb-5 p-4`}>
+    <div className={`${styles.CurrentRoundJumbotron} jumbotron d-flex justify-content-between mb-5 p-3`}>
       <div>
         <h2 className="m-0">Now playing</h2>
         <h1>Round {round.number}</h1>

--- a/src/CurrentRoundJumbotron/CurrentRoundJumbotron.module.css
+++ b/src/CurrentRoundJumbotron/CurrentRoundJumbotron.module.css
@@ -14,6 +14,6 @@
 }
 
 .currentRoundIcon {
-  width: 200px;
-  height: 200px;
+  width: calc(5rem + 8vw);
+  height: calc(5rem + 8vw);
 }

--- a/src/CurrentRoundJumbotron/CurrentRoundJumbotron.module.css
+++ b/src/CurrentRoundJumbotron/CurrentRoundJumbotron.module.css
@@ -1,15 +1,14 @@
 .CurrentRoundJumbotron {
-  
   background-color: black;
 }
 
 .CurrentRoundJumbotron h2 {
-  font-size: calc(0.5rem + 1vw);
+  font-size: calc(0.4rem + 1.5vw);
   color: #aaa;
 }
 
 .CurrentRoundJumbotron h1 {
-  font-size: calc(2rem + 3.5vw);
+  font-size: calc(1rem + 5vw);
   color: white;
 }
 

--- a/src/RoundIcon/RoundIcon.css
+++ b/src/RoundIcon/RoundIcon.css
@@ -2,27 +2,30 @@
   width: 100%;
   height: 100%;
   position: relative;
-  border: 1px solid lightgray;
   border-radius: 3px;
   background-color: white;
 }
 
 .cover-grid {
-  padding: 8px;
+  padding-left: 4%;
+  padding-right: 4%;
+  padding-top: 4%;
+  padding-bottom: 4%;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  width: fit-content;
   height: fit-content;
-  grid-gap: 8px;
+  grid-gap: 4%;
 }
 
 img {
-  width: 87px;
-  height: 87px;
+  width: 100%;
+  height: 100%;
 }
 
 .placeholder-img {
-  width: 87px;
-  height: 87px;
+  width: 100%;
+  height: 100%;
   background-color: #ddd;
 }
 
@@ -39,8 +42,10 @@ img {
 }
 
 .number-label {
-  width: 48px;
-  height: 48px;
+  min-width: 25%;
+  min-height: 25%;
+  max-width: 25%;
+  max-height: 25%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -50,12 +55,7 @@ img {
 
 .number-label p {
   margin: 0px;
-  font-size: 24px;
-  text-decoration: none;
+  font-size: 22px;
   color: black;
   font-weight: 200;
-}
-
-.number-label a {
-  text-decoration: none;
 }

--- a/src/RoundIcon/RoundIcon.js
+++ b/src/RoundIcon/RoundIcon.js
@@ -7,7 +7,7 @@ function RoundIcon({round, albums}) {
     <div className="RoundIcon position-relative">
       <div className="round-number-overlay">
         <div className="number-label">
-          <p>{round.number}</p>
+          <p className="m-0">{round.number}</p>
         </div>
       </div>
 

--- a/src/RoundListItem/RoundListItem.module.css
+++ b/src/RoundListItem/RoundListItem.module.css
@@ -1,8 +1,9 @@
 .RoundListItem {
-  width: 200px;
-  height: 200px;
+  width: 202px;
+  height: 202px;
   box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 5px;
   border-radius: 3px;
+  border: 1px solid #ddd;
   transition: 0.1s;
 }
 
@@ -24,13 +25,13 @@
   position: absolute;
   left: 0px;
   top: 0px;
-  width: 200px;
-  height: 200px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   background-color: black;
   transition: 0.2s;
 }
 
 .RoundListItem:hover > .disk {
-  left: 20px;
+  left: 25px;
 }


### PR DESCRIPTION
RoundIcons are currently defined using fixed pixel units. This pull request defines units in relative percents so RoundIcons can resize to fit their parent container.

However, this update does not make the round number label responsive since scaling fonts based on parent dimensions is hard. One drastic solution would be to generate round icons as images on the backend instead of building them client-side out of DOM elements. Resizing would then be a breeze, and loadtime for the past rounds list might be faster too.