### PR TITLE
#133 mislabeled points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * All tracks in a round album are shown by default.
 * The current round page can no longer be entered.
 * Various UI tweaks.
+* Fixed an issue where track names in album audio feature charts were displaying as RGB strings.
 
 ## 2022-03-28
 

--- a/src/AlbumView/AudioFeaturesChart.js
+++ b/src/AlbumView/AudioFeaturesChart.js
@@ -40,8 +40,7 @@ function AudioFeaturesChart({ tracks, features, colors, title }) {
       width={250}
       height={250}
       padding={{left: 30, right: 30, top: 60, bottom: 25}}
-      domainPadding={{x: [40, 40]}}
-      animate={{ duration: 500, easing: 'cubic' }}>
+      domainPadding={{x: [40, 40]}}>
       <VictoryBoxPlot
         boxWidth={35}
         data={boxData}


### PR DESCRIPTION
Fixed by removing the `animate` prop, which wasn't really necessary anyway. I also created an [issue](https://github.com/FormidableLabs/victory/issues/2368) for this bug over in the Victory repo.